### PR TITLE
fix: use random repo name

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const BlockService = require('ipfs-block-service')
  * @returns {void}
  */
 module.exports = async (IPLD) => {
-  const repo = new IPFSRepo('in-memory', {
+  const repo = new IPFSRepo('in-memory-' + Date.now(), {
     storageBackends: {
       root: MemoryDatastore,
       blocks: MemoryDatastore,


### PR DESCRIPTION
This module is only used for temporary repos, hence it makes sense to use
a random repo name that doesn't conflict with subsequent calls of `inMemory()`.

This problem was uncovered by the release of ipfs-repo 0.27.1 which is
now (correctly) throwing errors if an in-memory repository with the same
name is already locked.