### PR TITLE
Revert "Revert "fix: update deps to remove node globals (#10)""

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -280,8 +280,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -423,11 +422,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "base32.js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
-      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI="
-    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -488,6 +482,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -501,15 +496,15 @@
       "dev": true
     },
     "cids": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
+      "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
       "requires": {
         "buffer": "^5.5.0",
         "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
+        "multibase": "~0.7.0",
+        "multicodec": "^1.0.1",
+        "multihashes": "~0.4.17"
       }
     },
     "class-is": {
@@ -607,27 +602,51 @@
       }
     },
     "datastore-core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-      "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.0.0.tgz",
+      "integrity": "sha512-BS3bH+OOdW3ehY03awN6OhLhv6XvYUuQZBSUoIDA8qEyASBGj3nkBVfJBOEqozBXA0Q4/4QumkRxJfYnqrDy5w==",
       "requires": {
+        "buffer": "^5.5.0",
         "debug": "^4.1.1",
-        "interface-datastore": "~0.7.0"
+        "interface-datastore": "^0.8.2"
       },
       "dependencies": {
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
-        },
         "interface-datastore": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-          "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
+          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
           "requires": {
+            "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^1.1.2",
-            "uuid": "^3.2.2"
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^1.2.3",
+            "iso-random-stream": "^1.1.1",
+            "nanoid": "^3.0.2"
+          }
+        },
+        "ipfs-utils": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+          "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^5.4.2",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.0",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.7",
+            "merge-options": "^2.0.0",
+            "nanoid": "^2.1.11",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          },
+          "dependencies": {
+            "nanoid": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+              "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+            }
           }
         }
       }
@@ -644,6 +663,15 @@
         "mkdirp": "~0.5.1"
       },
       "dependencies": {
+        "datastore-core": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
+          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
+          "requires": {
+            "debug": "^4.1.1",
+            "interface-datastore": "~0.7.0"
+          }
+        },
         "err-code": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
@@ -661,6 +689,56 @@
         }
       }
     },
+    "datastore-idb": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/datastore-idb/-/datastore-idb-1.0.0.tgz",
+      "integrity": "sha512-vFPMwSrz7apTuG7mrtw7uBZRkHYteY+Quh8wCb8JPCpfOyn0APW4GPw6L8VKPEgxLP4yC2wR56S1q6gkhg/S2A==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "idb": "^5.0.2",
+        "interface-datastore": "^0.8.3"
+      },
+      "dependencies": {
+        "interface-datastore": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
+          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^1.2.3",
+            "iso-random-stream": "^1.1.1",
+            "nanoid": "^3.0.2"
+          }
+        },
+        "ipfs-utils": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+          "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^5.4.2",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.0",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.7",
+            "merge-options": "^2.0.0",
+            "nanoid": "^2.1.11",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          },
+          "dependencies": {
+            "nanoid": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+              "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+            }
+          }
+        }
+      }
+    },
     "datastore-level": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.14.1.tgz",
@@ -669,6 +747,34 @@
         "datastore-core": "~0.7.0",
         "interface-datastore": "^0.8.0",
         "level": "^5.0.1"
+      },
+      "dependencies": {
+        "datastore-core": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
+          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
+          "requires": {
+            "debug": "^4.1.1",
+            "interface-datastore": "~0.7.0"
+          },
+          "dependencies": {
+            "interface-datastore": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
+              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
+              "requires": {
+                "class-is": "^1.1.0",
+                "err-code": "^1.1.2",
+                "uuid": "^3.2.2"
+              }
+            }
+          }
+        },
+        "err-code": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+        }
       }
     },
     "debug": {
@@ -887,8 +993,9 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.js.ipfs.io/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "6.8.0",
@@ -1555,8 +1662,9 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.js.ipfs.io/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -1599,6 +1707,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "idb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.2.tgz",
+      "integrity": "sha512-53yU1RbSPkSkQxufmNgcBkxxnbsTMGaYCv2NwQDmBP75muYj4Z75DsvCqhCCivYcC1XaXDi9tZSUOfDQFxuABA=="
     },
     "ieee754": {
       "version": "1.1.13",
@@ -1782,98 +1895,217 @@
         "ipfs-utils": "^1.2.3",
         "iso-random-stream": "^1.1.1",
         "nanoid": "^3.0.2"
-      }
-    },
-    "ipfs-block": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
-      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
-      "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
+      },
+      "dependencies": {
+        "ipfs-utils": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+          "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^5.4.2",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.0",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.7",
+            "merge-options": "^2.0.0",
+            "nanoid": "^2.1.11",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          },
+          "dependencies": {
+            "nanoid": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+              "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+            }
+          }
+        }
       }
     },
     "ipfs-block-service": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.16.0.tgz",
-      "integrity": "sha512-cSITuhI8Bizrmks8rC6SmFcSbtUf9bIUPbpHetwb7T3raSseODx80Wy51JKXFkMyLAuWYHOfDie0J/kf5csGKw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.17.0.tgz",
+      "integrity": "sha512-fML9zvPG7uVY7rkg9QzhkZYpZXT3qhU5ITU9fgSpGBxZxutwyLjO7tnYkbguiJ7exmMMV2hXsZvFirfluhmruA==",
       "requires": {
+        "err-code": "^2.0.0",
         "streaming-iterables": "^4.1.0"
       }
     },
     "ipfs-repo": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.30.1.tgz",
-      "integrity": "sha512-t/RG/agHGRJ1yyzrwaFRDUyTZgJcdhSGFoeRIrCJuxxApjrXQZMee58SZL9al+jArRu+5sbZqcepLwwdIV95PA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-2.0.0.tgz",
+      "integrity": "sha512-PEA/SNpTcj+zHZnONe+V8+AvueZYVH52B4hPxLBMmJbd27D0rdrsJ0fTb5S1Vish2bVCd6znb3d8qDEZnSm7lQ==",
       "requires": {
-        "base32.js": "~0.1.0",
         "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
         "bytes": "^3.1.0",
-        "cids": "~0.7.0",
-        "datastore-core": "~0.7.0",
+        "cids": "^0.8.0",
+        "datastore-core": "^1.0.0",
         "datastore-fs": "~0.9.0",
+        "datastore-idb": "^1.0.0",
         "datastore-level": "~0.14.0",
         "debug": "^4.1.0",
         "err-code": "^2.0.0",
-        "interface-datastore": "^0.8.0",
-        "ipfs-block": "~0.8.1",
-        "ipfs-repo-migrations": "~0.1.0",
+        "interface-datastore": "^0.8.3",
+        "ipfs-repo-migrations": "^0.2.0",
+        "ipfs-utils": "^2.2.0",
+        "ipld-block": "^0.9.1",
         "just-safe-get": "^2.0.0",
         "just-safe-set": "^2.1.0",
-        "lodash.has": "^4.5.2",
+        "multibase": "^0.7.0",
         "p-queue": "^6.0.0",
         "proper-lockfile": "^4.0.0",
         "sort-keys": "^4.0.0"
+      },
+      "dependencies": {
+        "interface-datastore": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
+          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^1.2.3",
+            "iso-random-stream": "^1.1.1",
+            "nanoid": "^3.0.2"
+          },
+          "dependencies": {
+            "ipfs-utils": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+              "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+              "requires": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^5.4.2",
+                "err-code": "^2.0.0",
+                "fs-extra": "^9.0.0",
+                "is-electron": "^2.2.0",
+                "iso-url": "^0.4.7",
+                "it-glob": "0.0.7",
+                "merge-options": "^2.0.0",
+                "nanoid": "^2.1.11",
+                "node-fetch": "^2.6.0",
+                "stream-to-it": "^0.2.0"
+              },
+              "dependencies": {
+                "nanoid": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+                  "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+                }
+              }
+            }
+          }
+        }
       }
     },
     "ipfs-repo-migrations": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-0.1.1.tgz",
-      "integrity": "sha512-Id8K32l7bEqMt0YxfDUAAiMFkfFr9pslOT0xg3EqTrPc0AeXQ5sZu6y69p5TI7N+A28PhrGgMU40R7IQ8Mb7sg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-0.2.0.tgz",
+      "integrity": "sha512-gaApKQyxpX1nB5DGkfZ9GCziFLhFz37oLmynzTmkwVzqVPmcJhgYzfcmcsUUmr8eEDHZTSxZkv+d7uZ0HEAadA==",
       "requires": {
-        "chalk": "^2.4.2",
+        "buffer": "^5.5.0",
+        "chalk": "^4.0.0",
         "datastore-fs": "~0.9.1",
-        "datastore-level": "~0.12.1",
+        "datastore-idb": "^1.0.0",
         "debug": "^4.1.0",
-        "interface-datastore": "~0.8.0",
+        "interface-datastore": "~0.8.3",
         "proper-lockfile": "^4.1.1",
         "yargs": "^14.2.0",
         "yargs-promise": "^1.1.0"
       },
       "dependencies": {
-        "datastore-level": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.12.1.tgz",
-          "integrity": "sha512-PxUIrH/0ijuaJLypOx1XjOIvsZCZcN1qZ3HKyqXFhU8Wpkn01/Q/9nL/MM1tKK1EwOTFmgXKUtFbO27gf6LpcQ==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "requires": {
-            "datastore-core": "~0.7.0",
-            "interface-datastore": "~0.7.0",
-            "level": "^5.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "interface-datastore": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
+          "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^1.2.3",
+            "iso-random-stream": "^1.1.1",
+            "nanoid": "^3.0.2"
+          }
+        },
+        "ipfs-utils": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
+          "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^5.4.2",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.0",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.7",
+            "merge-options": "^2.0.0",
+            "nanoid": "^2.1.11",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
           },
           "dependencies": {
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
+            "nanoid": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+              "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
             }
           }
         },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
     "ipfs-utils": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
-      "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.2.0.tgz",
+      "integrity": "sha512-V4pq/BYpWupB+QdVEBnNl/B7uMx3glLVCGAQRGI66DQJTa78vdcEyD8XeRB4wUUFMbxUo1s0J0CH/pJsYNgF9A==",
       "requires": {
         "abort-controller": "^3.0.0",
         "buffer": "^5.4.2",
@@ -1883,16 +2115,19 @@
         "iso-url": "^0.4.7",
         "it-glob": "0.0.7",
         "merge-options": "^2.0.0",
-        "nanoid": "^2.1.11",
+        "nanoid": "^3.1.3",
         "node-fetch": "^2.6.0",
         "stream-to-it": "^0.2.0"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "2.1.11",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
-        }
+      }
+    },
+    "ipld-block": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.9.1.tgz",
+      "integrity": "sha512-ypzGNd6VraQx3sU1x8w4/vJPwVKCZgRRLYuXHLJsvW/KQ9xjxN+HkcJgKw2E9up6G7c+1kIWNGnyxsPWjc27pQ==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "cids": "~0.8.0",
+        "class-is": "^1.1.0"
       }
     },
     "is-arguments": {
@@ -2399,11 +2634,6 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2468,9 +2698,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multibase": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
       "requires": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
@@ -2493,17 +2723,6 @@
         "buffer": "^5.5.0",
         "multibase": "^0.7.0",
         "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        }
       }
     },
     "mute-stream": {
@@ -3615,6 +3834,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "license": "MIT",
   "dependencies": {
     "hat": "0.0.3",
-    "interface-datastore": "^0.8.0",
-    "ipfs-block-service": "^0.16.0",
-    "ipfs-repo": "^0.30.1"
+    "interface-datastore": "^0.8.3",
+    "ipfs-block-service": "^0.17.0",
+    "ipfs-repo": "^2.0.0"
   },
   "devDependencies": {
     "nyc": "^15.0.1",


### PR DESCRIPTION
BREAKING CHANGE: Use ipld-block instead of ipfs-block.

This reverts commit 835a54c6f6f2bebf3eccef7094a65b53a9b0c3c6.