### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -509,12 +509,12 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "cbor": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.2.tgz",
-      "integrity": "sha512-6JiKVURxxO92FntzTJq54QdN/8fBaBwD7+nNyGIAi1HL9mBgU3YK6ULV8k7WTuT/EwfRsjy3MuqDKlkQMCmfXg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.1.0.tgz",
+      "integrity": "sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==",
       "requires": {
         "bignumber.js": "^9.0.0",
-        "nofilter": "^1.0.3"
+        "nofilter": "^1.0.4"
       }
     },
     "chalk": {
@@ -535,15 +535,15 @@
       "dev": true
     },
     "cids": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+      "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
       "requires": {
-        "buffer": "^5.6.0",
         "class-is": "^1.1.0",
-        "multibase": "^1.0.0",
-        "multicodec": "^1.0.1",
-        "multihashes": "^1.0.1"
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "uint8arrays": "^1.0.0"
       }
     },
     "class-is": {
@@ -678,24 +678,24 @@
       }
     },
     "datastore-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.1.0.tgz",
-      "integrity": "sha512-tn42Qy6t1V5otG4R3hq7yW4vpNaKc8/GXEYnLv8oeGNSQfEWPnfz1x5Sto080N7IsluzOUWK/W+a4m4Er8DnAA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.0.tgz",
+      "integrity": "sha512-E6SS3GEZNMCRZScWO98qQ14MIb7+3MLsJtcgla/ULCjfnhThsUE21HN+wT0+QLoYrKR54puWy/3XKp5N+5+zyA==",
       "requires": {
-        "buffer": "^5.5.0",
         "debug": "^4.1.1",
-        "interface-datastore": "^1.0.2"
+        "interface-datastore": "^2.0.0",
+        "ipfs-utils": "^2.3.1"
       }
     },
     "datastore-fs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-1.1.0.tgz",
-      "integrity": "sha512-z/lsSMxi7omrPwCgGjZ1OrPN0cq35sFMWhTHnnF1ekvD3fxntB1gNqEi9ioMMJNX8OQap7JvYT40LdtZZx7mTg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.0.tgz",
+      "integrity": "sha512-QSs8VXNnG3mgK+MNrzv/FThprjOkaMNbejROUQZFi8MeqE/SLNkNCWWlA3wyYH5QeyVkshnKGoTtw6dKYKhx7g==",
       "requires": {
-        "datastore-core": "^1.1.0",
+        "datastore-core": "^2.0.0",
         "fast-write-atomic": "^0.2.0",
-        "glob": "^7.1.3",
-        "interface-datastore": "^1.0.2",
+        "interface-datastore": "^2.0.0",
+        "it-glob": "0.0.8",
         "mkdirp": "^1.0.4"
       },
       "dependencies": {
@@ -707,12 +707,12 @@
       }
     },
     "datastore-level": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-1.1.0.tgz",
-      "integrity": "sha512-XEuXC3mq2BTUdhOvx7vwD93GN1O8SJf1HL/EOlmVcxLt3EHtDpX5pqZmiDdrXIAfe4uiEuSfFu2tKycuz1PMZA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-2.0.0.tgz",
+      "integrity": "sha512-52qSxZG75QRqO502cSvnYnXj/5sO29Dvtd9uuiRLSzUaSPher8pS0hl5xzlx7zglpzAjQpjaq9oy2UFO6vMn6g==",
       "requires": {
-        "datastore-core": "^1.1.0",
-        "interface-datastore": "^1.0.2",
+        "datastore-core": "^2.0.0",
+        "interface-datastore": "^2.0.0",
         "level": "^5.0.1"
       }
     },
@@ -1578,7 +1578,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.js.ipfs.io/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1618,6 +1619,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1754,6 +1756,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.js.ipfs.io/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1876,14 +1879,13 @@
       }
     },
     "interface-datastore": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-      "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
+      "integrity": "sha512-wOImix5uVEZWo+8zPSRMJ9nHbszZi3PhZ14KHLN7oRQjaYQtjtOpYj6n5EXTjDAfIQI8KN9vntHXxyAw1lcRIA==",
       "requires": {
-        "buffer": "^5.5.0",
         "class-is": "^1.1.0",
         "err-code": "^2.0.1",
-        "ipfs-utils": "^2.2.2",
+        "ipfs-utils": "^2.3.1",
         "iso-random-stream": "^1.1.1",
         "it-all": "^1.0.2",
         "it-drain": "^1.0.1",
@@ -1907,54 +1909,54 @@
       }
     },
     "ipfs-repo": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-5.0.0.tgz",
-      "integrity": "sha512-V+WdgIqFbt5H1+6rNkYLCXlrLB4kO1MgZeagPJ3V6y5GPiCU3hTmqaNmNqzYA9ko4yGjdypK0fSFRw2LK2Q9/g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-6.0.0.tgz",
+      "integrity": "sha512-Lonq7fkSuBGO7R+P/iAPcIwIgFd4tXEcAbPmjyJoWWP1Lqe/5414q6OqVsMrbLzqPva6Cmthdr8MqW5zb60dlg==",
       "requires": {
         "bignumber.js": "^9.0.0",
-        "buffer": "^5.6.0",
         "bytes": "^3.1.0",
-        "cids": "^0.8.0",
-        "datastore-core": "^1.1.0",
-        "datastore-fs": "^1.1.0",
-        "datastore-level": "^1.1.0",
+        "cids": "^1.0.0",
+        "datastore-core": "^2.0.0",
+        "datastore-fs": "^2.0.0",
+        "datastore-level": "^2.0.0",
         "debug": "^4.1.0",
         "err-code": "^2.0.0",
-        "interface-datastore": "^1.0.2",
-        "ipfs-repo-migrations": "^2.0.0",
-        "ipfs-utils": "^2.2.0",
-        "ipld-block": "^0.9.1",
+        "interface-datastore": "^2.0.0",
+        "ipfs-repo-migrations": "^3.0.0",
+        "ipfs-utils": "^2.3.1",
+        "ipld-block": "^0.10.0",
         "it-map": "^1.0.2",
         "it-pushable": "^1.4.0",
         "just-safe-get": "^2.0.0",
         "just-safe-set": "^2.1.0",
-        "multibase": "^1.0.1",
+        "multibase": "^3.0.0",
         "p-queue": "^6.0.0",
         "proper-lockfile": "^4.0.0",
-        "sort-keys": "^4.0.0"
+        "sort-keys": "^4.0.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipfs-repo-migrations": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-2.0.1.tgz",
-      "integrity": "sha512-kKo5TI81i04nFnjuSDCdCejKeNwX7LCk7PRbcT19YQd/1s98lDT7xY3wLpa02VOUkuQsQk2/NujAutzHdGiTrQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-3.0.0.tgz",
+      "integrity": "sha512-dd0JQtpASIJeXCuTLfQiZUYUH2vgxqKyiCK8LCJEJ71rizu1J+ljhHDAxk1fV6cW6RZjvEm9tRKrIeG3ZAl7NA==",
       "requires": {
-        "buffer": "^5.6.0",
         "cbor": "^5.0.2",
         "chalk": "^4.0.0",
-        "cids": "^0.8.3",
-        "datastore-core": "^1.1.0",
-        "datastore-fs": "^1.0.0",
-        "datastore-level": "^1.1.0",
+        "cids": "^1.0.0",
+        "datastore-core": "^2.0.0",
+        "datastore-fs": "^2.0.0",
+        "datastore-level": "^2.0.0",
         "debug": "^4.1.0",
         "fnv1a": "^1.0.1",
-        "interface-datastore": "^1.0.2",
-        "ipld-dag-pb": "^0.18.5",
-        "multibase": "^1.0.1",
-        "multicodec": "^1.0.3",
-        "multihashing-async": "^1.0.0",
+        "interface-datastore": "^2.0.0",
+        "ipld-dag-pb": "^0.20.0",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
         "proper-lockfile": "^4.1.1",
-        "protons": "^1.2.1",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.0.0",
         "varint": "^5.0.0",
         "yargs": "^15.3.1",
         "yargs-promise": "^1.1.0"
@@ -2026,42 +2028,28 @@
       }
     },
     "ipld-block": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.9.2.tgz",
-      "integrity": "sha512-/i99foB+QI8WhyZWu6ZVPFw2sP6kzZSnnjPNlxxrgaJeFX22w2z00nYWafY2YYYP4mZ9xkLZDSS/msli7XXyvw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.0.tgz",
+      "integrity": "sha512-2Bh2byWQdvBPvb/jXcOkMu0ejKgb13LrBOy2cC9z/qBD2W7Og6t6XA1Ui+xnxZeEHeDDcFnPLayL6n0bmT+1FA==",
       "requires": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0"
       }
     },
     "ipld-dag-pb": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
-      "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
+      "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
       "requires": {
-        "buffer": "^5.6.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "multicodec": "^1.0.1",
-        "multihashing-async": "~0.8.1",
-        "protons": "^1.0.2",
-        "stable": "^0.1.8"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "protons": "^2.0.0",
+        "reset": "^0.1.0",
+        "run": "^1.4.0",
+        "stable": "^0.1.8",
+        "uint8arrays": "^1.0.0"
       }
     },
     "is-arguments": {
@@ -2721,44 +2709,67 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multibase": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+      "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
       "requires": {
         "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
+        "web-encoding": "^1.0.2"
       }
     },
     "multicodec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+      "integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
       "requires": {
-        "buffer": "^5.6.0",
+        "uint8arrays": "1.0.0",
         "varint": "^5.0.0"
       }
     },
     "multihashes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+      "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
       "requires": {
-        "buffer": "^5.6.0",
-        "multibase": "^1.0.1",
+        "multibase": "^3.0.0",
+        "uint8arrays": "^1.0.0",
         "varint": "^5.0.0"
       }
     },
     "multihashing-async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-      "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.0.tgz",
+      "integrity": "sha512-zcOfmjhkAxpzERC9vfdfEk73HOLFixIpcSgJ39Q7UVfct92V21SR/pkruv7I837WxPbKfmF4zmqR82hlLvCMrQ==",
       "requires": {
         "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
         "err-code": "^2.0.0",
         "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
+        "multihashes": "^2.0.0",
+        "murmurhash3js-revisited": "^3.0.0",
+        "uint8arrays": "^1.0.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-2.0.0.tgz",
+          "integrity": "sha512-xIrqUVsinSlFjqj+OtEgCJ6MRl5hXjHMBPWsUt1ZGSRMx8rzm+7hCLE4wDeSA3COomlUC9zHCoUlvWjvAMtfDg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0",
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "multihashes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-2.0.0.tgz",
+          "integrity": "sha512-Mp94Y+7h3oWQx8JickVghlWR6VhRPDnlv/KZEUyNP0ISSkNEe3kQkWoyIGt1B45D6cTLoulg+MP6bugVewx32Q==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^2.0.0",
+            "varint": "^5.0.0",
+            "web-encoding": "^1.0.2"
+          }
+        }
       }
     },
     "murmurhash3js-revisited": {
@@ -2773,9 +2784,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.10.tgz",
-      "integrity": "sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w=="
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "napi-macros": {
       "version": "2.0.0",
@@ -2814,9 +2825,9 @@
       }
     },
     "nofilter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.3.tgz",
-      "integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -3102,6 +3113,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.js.ipfs.io/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3232,7 +3244,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.js.ipfs.io/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -3418,13 +3431,13 @@
       "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
     },
     "protons": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
-      "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
+      "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
       "requires": {
-        "buffer": "^5.5.0",
         "protocol-buffers-schema": "^3.3.1",
         "signed-varint": "^2.0.1",
+        "uint8arrays": "^1.0.0",
         "varint": "^5.0.0"
       }
     },
@@ -3556,6 +3569,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
+    "reset": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/reset/-/reset-0.1.0.tgz",
+      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs="
+    },
     "resolve": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.1.tgz",
@@ -3602,6 +3620,14 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
+      "integrity": "sha1-4X2ekEOrL+F3dsspnhI3848LT/o=",
+      "requires": {
+        "minimatch": "*"
       }
     },
     "run-async": {
@@ -4037,6 +4063,15 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uint8arrays": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+      "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+      "requires": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.2"
+      }
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -4088,6 +4123,11 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
       "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+    },
+    "web-encoding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.2.tgz",
+      "integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA=="
     },
     "which": {
       "version": "2.0.2",
@@ -4218,7 +4258,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.js.ipfs.io/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,8 +1900,9 @@
       }
     },
     "ipfs-block-service": {
-      "version": "github:ipfs/js-ipfs-block-service#d565954e8e0a01ff52ddb0bf72c8990f14039246",
-      "from": "github:ipfs/js-ipfs-block-service#fix/replace-buffers-with-uint8arrays",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.18.0.tgz",
+      "integrity": "sha512-tye5Uxbf3bYlfcGkV3CspP2JNcM2Ggm/5Kxph0jGKtAZtgfFxUq3NeSmvS6nGtZZBaFP4nwRF2yq7dQMALWzVg==",
       "requires": {
         "err-code": "^2.0.0",
         "streaming-iterables": "^5.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,12 +1900,11 @@
       }
     },
     "ipfs-block-service": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.17.0.tgz",
-      "integrity": "sha512-fML9zvPG7uVY7rkg9QzhkZYpZXT3qhU5ITU9fgSpGBxZxutwyLjO7tnYkbguiJ7exmMMV2hXsZvFirfluhmruA==",
+      "version": "github:ipfs/js-ipfs-block-service#d565954e8e0a01ff52ddb0bf72c8990f14039246",
+      "from": "github:ipfs/js-ipfs-block-service#fix/replace-buffers-with-uint8arrays",
       "requires": {
         "err-code": "^2.0.0",
-        "streaming-iterables": "^4.1.0"
+        "streaming-iterables": "^5.0.2"
       }
     },
     "ipfs-repo": {
@@ -3842,9 +3841,9 @@
       }
     },
     "streaming-iterables": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-      "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.2.tgz",
+      "integrity": "sha512-9z5iBWe9WXzdT0X1JT9fVC0mCcVxWt5yzZMBUIgjZnt2k23+UQF8Ac6kiI8DnlYZJn5iysvxKl3uGzlijMQ+/g=="
     },
     "string-width": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "hat": "0.0.3",
     "interface-datastore": "^2.0.0",
-    "ipfs-block-service": "^0.17.0",
+    "ipfs-block-service": "ipfs/js-ipfs-block-service#fix/replace-buffers-with-uint8arrays",
     "ipfs-repo": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "license": "MIT",
   "dependencies": {
     "hat": "0.0.3",
-    "interface-datastore": "^1.0.4",
+    "interface-datastore": "^2.0.0",
     "ipfs-block-service": "^0.17.0",
-    "ipfs-repo": "^5.0.0"
+    "ipfs-repo": "^6.0.0"
   },
   "devDependencies": {
     "nyc": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "hat": "0.0.3",
     "interface-datastore": "^2.0.0",
-    "ipfs-block-service": "ipfs/js-ipfs-block-service#fix/replace-buffers-with-uint8arrays",
+    "ipfs-block-service": "^0.18.0",
     "ipfs-repo": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Depends on:

- [x] https://github.com/ipfs/js-ipfs-block-service/pull/105

BREAKING CHANGES:

- The `ipfs-repo` instance exposed via the blockstore used by the
  instance of IPLD returned by this module returns `Unint8Array`s
  instead of node `Buffer`s